### PR TITLE
Suppprt plugin specific log level

### DIFF
--- a/lib/fluent/plugin/out_azuresearch.rb
+++ b/lib/fluent/plugin/out_azuresearch.rb
@@ -4,6 +4,10 @@ module Fluent
   class AzureSearchOutput < BufferedOutput
     Plugin.register_output('azuresearch', self)
 
+    unless method_defined?(:log)
+        define_method('log') { $log }
+    end
+
     def initialize
         super
         require 'msgpack'
@@ -79,7 +83,7 @@ DESC
             res = @client.add_documents(@search_index, documents)
             puts res
         rescue Exception => ex
-            $log.fatal "UnknownError: '#{ex}'"
+            log.fatal "UnknownError: '#{ex}'"
                           + ", data=>" + (documents.to_json).to_s
         end
     end


### PR DESCRIPTION
Recent Fluentd supports plugin specific log level with `@log_level`
parameter.

```aconf
<match **>
  @type azuresearch
  @log_level warn
  # etc.
</match>
```