### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-azuresearch.gemspec
+++ b/fluent-plugin-azuresearch.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|gem|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "rest-client"
   gem.add_development_dependency "bundler", "~> 1.11"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "test-unit"
 end
-

--- a/lib/fluent/plugin/azuresearch/client.rb
+++ b/lib/fluent/plugin/azuresearch/client.rb
@@ -16,8 +16,8 @@ module Fluent::Plugin
         end 
 
         def add_documents(index_name, documents, merge=true)
-            raise ConfigError, 'no index_name' if index_name.empty?
-            raise ConfigError, 'no documents' if documents.empty?
+            raise Fluent::ConfigError, 'no index_name' if index_name.empty?
+            raise Fluent::ConfigError, 'no documents' if documents.empty?
             action = merge ? 'mergeOrUpload' : 'upload' 
             for document in documents
                 document['@search.action'] = action

--- a/lib/fluent/plugin/azuresearch/client.rb
+++ b/lib/fluent/plugin/azuresearch/client.rb
@@ -1,4 +1,4 @@
-module Fluent
+module Fluent::Plugin
   module AzureSearch
     class Client
 

--- a/lib/fluent/plugin/out_azuresearch.rb
+++ b/lib/fluent/plugin/out_azuresearch.rb
@@ -58,7 +58,7 @@ DESC
     def start
         super
         # start
-        @client=Fluent::AzureSearch::Client::new( @endpoint, @api_key )
+        @client=Fluent::Plugin::AzureSearch::Client::new( @endpoint, @api_key )
     end
 
     def shutdown

--- a/lib/fluent/plugin/out_azuresearch.rb
+++ b/lib/fluent/plugin/out_azuresearch.rb
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 require 'fluent/plugin/output'
+require 'msgpack'
+require 'time'
+require 'fluent/plugin/azuresearch/client'
 
 module Fluent::Plugin
   class AzureSearchOutput < Output
@@ -16,9 +19,6 @@ module Fluent::Plugin
 
     def initialize
         super
-        require 'msgpack'
-        require 'time'
-        require 'fluent/plugin/azuresearch/client'
     end
 
     config_param :endpoint, :string,

--- a/lib/fluent/plugin/out_azuresearch.rb
+++ b/lib/fluent/plugin/out_azuresearch.rb
@@ -13,14 +13,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    unless method_defined?(:log)
-        define_method('log') { $log }
-    end
-
-    def initialize
-        super
-    end
-
     config_param :endpoint, :string,
                  :desc => "Azure Search Endpoint URL"
     config_param :api_key, :string, :secret => true,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,7 +23,10 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 require 'fluent/plugin/out_azuresearch'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_azuresearch.rb
+++ b/test/plugin/test_azuresearch.rb
@@ -18,57 +18,57 @@ class AzureSearchOutputTest < Test::Unit::TestCase
   #   utc
   # ]
 
-  def create_driver(conf = CONFIG, tag='azuresearch.test')
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::AzureSearchOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::AzureSearchOutput).configure(conf)
   end
 
   def test_configure
-    #### set configurations
-    # d = create_driver %[
-    #   path test_path
-    #   compress gz
-    # ]
-    #### check configurations
-    # assert_equal 'test_path', d.instance.path
-    # assert_equal :gz, d.instance.compress
+    d = create_driver
+
+    assert_equal 'https://AZURE_SEARCH_ACCOUNT.search.windows.net', d.instance.endpoint
+    assert_equal 'AZURE_SEARCH_API_KEY', d.instance.api_key
+    assert_equal 'messages', d.instance.search_index
+    assert_equal ["id", "user_name", "message", "tag", "created_at"], d.instance.column_names
   end
 
   def test_format
     d = create_driver
 
-    # time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    # d.emit({"a"=>1}, time)
-    # d.emit({"a"=>2}, time)
+    time = event_time("2011-01-02 13:14:15 UTC")
+    d.run(default_tag: 'documentdb.test') do
+      d.feed(time, {"a"=>1})
+      d.feed(time, {"a"=>2})
+    end
 
-    # d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n]
-    # d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n]
-
-    # d.run
+    # assert_equal EXPECTED1, d.formatted[0]
+    # assert_equal EXPECTED2, d.formatted[1]
   end
 
   def test_write
     d = create_driver
 
-    time = Time.parse("2016-01-28 13:14:15 UTC").to_i
-    d.emit(
-        {
-            "postid" => "10001",
-            "user"=> "ladygaga",
-            "content" => "post by ladygaga",
-            "tag" => "azuresearch.msg",
-            "posttime" =>"2016-01-31T00:00:00Z"
-        }, time)
+    time = event_time("2016-01-28 13:14:15 UTC")
+    data = d.run(default_tag: 'azuresearch.test') do
+      d.feed(
+          time,
+          {
+              "postid" => "10001",
+              "user"=> "ladygaga",
+              "content" => "post by ladygaga",
+              "tag" => "azuresearch.msg",
+              "posttime" =>"2016-01-31T00:00:00Z"
+          })
 
-    d.emit(
-        {
-            "postid" => "10002",
-            "user"=> "katyperry",
-            "content" => "post by katyperry",
-            "tag" => "azuresearch.msg",
-            "posttime" => "2016-01-31T00:00:00Z"
-        }, time)
-
-    data = d.run
+      d.feed(
+          time,
+          {
+              "postid" => "10002",
+              "user"=> "katyperry",
+              "content" => "post by katyperry",
+              "tag" => "azuresearch.msg",
+              "posttime" => "2016-01-31T00:00:00Z"
+          })
+    end
     puts data
     # ### FileOutput#write returns path
     # path = d.run
@@ -76,4 +76,3 @@ class AzureSearchOutputTest < Test::Unit::TestCase
     # assert_equal expect_path, path
   end
 end
-


### PR DESCRIPTION
I've tried to migrate to use Fluentd v0.14 Output Plugin API in this plugin.
How about use v0.14 API in this plugin?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,